### PR TITLE
Potential fix for code scanning alert no. 81: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -45,6 +45,12 @@ export function showProductReviews () {
         res.status(400).json({ error: 'Invalid Product ID for challenge' })
         return
       }
+      // Ensure id is parsed as an integer for $where injection safety
+      id = parseInt(id, 10)
+      if (isNaN(id)) {
+        res.status(400).json({ error: 'Product ID conversion error' })
+        return
+      }
     }
 
     // Measure how long the query takes, to check if there was a nosql dos attack


### PR DESCRIPTION
Potential fix for [https://github.com/josihonori-cyber/juice-shop-ada-1466/security/code-scanning/81](https://github.com/josihonori-cyber/juice-shop-ada-1466/security/code-scanning/81)

To mitigate code injection in the `$where` clause, do not concatenate tainted user input directly into a string that is evaluated as code. Instead, use parameterized queries or restrict to plain MongoDB queries where possible. In this case, because `id` is validated to be digits only, it’s safe to use it as a number directly in the query—for the challenge we can keep logic but use strict type conversion and avoid any code evaluation.

So, rather than generating a `$where` query with `'this.product == ' + id`, we can generate a query like `{ product: Number(id) }` even for challenge mode, if you wish to keep the challenge focused on NoSQL aspects. If the challenge specifically requires the `$where` behavior, ensure that `id` is parsed as an integer and never used directly as a string in the template. 

**Steps:**
- On line 43, after truncation/validation, parse `id` to an integer.
- On line 56, construct `$where` as `'this.product == ' + id` where `id` is guaranteed an integer, *not a string*.
- Make this parsing explicit and fail if parseInt fails.
- (Optional) Alternatively, avoid `$where` entirely and use `{ product: id }`; but if the challenge requires `$where`, then ensure only numbers.
- No external library is needed, just use parseInt and strict validation.

All the required changes are in `routes/showProductReviews.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
