### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/josihonori-cyber/juice-shop-ada-1466/security/code-scanning/53](https://github.com/josihonori-cyber/juice-shop-ada-1466/security/code-scanning/53)

To fix the code injection vulnerability, we should replace the use of the `$where` operator with a safe, parameterized query. Instead of executing arbitrary JavaScript via `$where`, directly query for the `orderId` field using the standard MongoDB query syntax (e.g., `{ orderId: id }`). This approach is safe, avoids the security risk inherent to `$where`, and preserves the business logic: retrieving orders matching the given `orderId`. Only change the query method on line 18; the rest of the logic should remain unchanged. No new methods are required, and no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
